### PR TITLE
Develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ target_sources(avalanche
 			src/string_functions.cpp
 )
 
-target_compile_options(avalanche PRIVATE -Wall -Wextra -Wpedantic)
+target_compile_options(avalanche PRIVATE -Wall -Wextra -Wpedantic -g)
 
 target_include_directories(avalanche PUBLIC include/)
 target_link_libraries(avalanche -lcrypto)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,16 @@ cmake_minimum_required(VERSION 3.16)
 
 project(AVA LANGUAGES CXX)
 
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
+        message(FATAL_ERROR "GCC version must be at least 12!  " ${CMAKE_CXX_COMPILER_VERSION})
+    endif()
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14)
+		message(FATAL_ERROR "Clang version must be at least 14!  " ${CMAKE_CXX_COMPILER_VERSION})
+    endif()
+endif()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/include/string_functions.hpp
+++ b/include/string_functions.hpp
@@ -1,11 +1,11 @@
 #pragma once
 #include <iostream>
 
-/*hex string to binary string stream*/
+/* convert hex string to binary (in string form) */
 std::string strtb(std::string_view hex);
 
-/*hex char to int*/
+/* hex char to int */
 inline unsigned int value(char c);
 
-/*function to xor hex strings*/
+/* function to xor hex strings */
 std::string strXor(std::string_view s1, std::string_view s2);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,10 +33,11 @@ std::vector<std::unique_ptr<std::array<uint8_t, Bytes>>> generateData(std::size_
         throw std::invalid_argument("Cannot have a size larger than the number of bits.");
     }
 
-    std::vector<std::unique_ptr<std::array<uint8_t, Bytes>>> data(size);
+    std::vector<std::unique_ptr<std::array<uint8_t, Bytes>>> data;
+    data.reserve(size);
 
-    for (auto& ptr : data) {
-        ptr = std::move(std::unique_ptr<std::array<uint8_t, Bytes>>(new std::array<uint8_t, Bytes>));
+    for (std::size_t i = 0; i < size; i++) {
+        data.emplace_back(std::make_unique<std::array<uint8_t, Bytes>>());
     }
 
     /* all uint8_t arrays must be different from each other by 2 bits and 1 from the parent uint8_t array */
@@ -72,7 +73,6 @@ int main() {
     /* number of bytes that each hash will be constructed from */
     const std::size_t bytes = 10;
 
-    /* parent uint8_t array to compare our data with */
     std::unique_ptr<std::array<uint8_t, bytes>> parent(new std::array<uint8_t, bytes>());
 
     std::vector<std::unique_ptr<std::array<uint8_t, bytes>>> data(generateData<bytes>(hashes_count));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,9 +33,11 @@ std::vector<std::unique_ptr<std::array<uint8_t, Bytes>>> generateData(std::size_
         throw std::invalid_argument("Cannot have a size larger than the number of bits.");
     }
 
+    /* using unique_ptr<T> to store the arrays to prevent problems with allocating big blocks */
     std::vector<std::unique_ptr<std::array<uint8_t, Bytes>>> data;
     data.reserve(size);
 
+    /* initializing the vector */
     for (std::size_t i = 0; i < size; i++) {
         data.emplace_back(std::make_unique<std::array<uint8_t, Bytes>>());
     }
@@ -69,20 +71,24 @@ int countDiffBits(std::string_view first_string, std::string_view second_string)
 
 int main() {
     /* number of hashes to compare to parent hash */
-    const std::size_t hashes_count = 60;
-    /* number of bytes that each hash will be constructed from */
-    const std::size_t bytes = 10;
+    const std::size_t hashes_count = 100;
 
+    /* number of bytes that each hash will be constructed from */
+    const std::size_t bytes = 64;
+
+    /* using unique_ptr<T> to store the array to prevent problems with allocating big blocks */
     std::unique_ptr<std::array<uint8_t, bytes>> parent(new std::array<uint8_t, bytes>());
 
+    /* initializing the array */
     std::vector<std::unique_ptr<std::array<uint8_t, bytes>>> data(generateData<bytes>(hashes_count));
 
     /* sum the number of different bits from all hashes */
     int count = 0;
     for (const auto& ptr : data) {
-        // printBits(arr);
+        // printBits(ptr);
         count += countDiffBits(sha256(parent), sha256(ptr));
     }
+
     /* output the average hamming weight, which should be something around 0.5 */
     std::cout << "average hamming weight is: " << count / (float)((hashes_count)*256) << '\n';
     return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <bitset>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
 #include <memory>
@@ -12,11 +13,11 @@
 
 /* OpenSSL sha256 function */
 template <std::size_t Size>
-std::string sha256(const std::array<uint8_t, Size> arr) {
+std::string sha256(const std::unique_ptr<std::array<uint8_t, Size>>& arr) {
     unsigned char hash[SHA256_DIGEST_LENGTH];
     SHA256_CTX sha256;
     SHA256_Init(&sha256);
-    SHA256_Update(&sha256, arr.data(), Size);
+    SHA256_Update(&sha256, (*arr).data(), Size);
     SHA256_Final(hash, &sha256);
     std::stringstream ss;
     for (int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
@@ -27,27 +28,31 @@ std::string sha256(const std::array<uint8_t, Size> arr) {
 
 /* generate a vector of arrays of uint8_t's to feed into sha256 */
 template <std::size_t Bytes>
-std::unique_ptr<std::vector<std::array<uint8_t, Bytes>>> generateData(std::size_t size) {
+std::vector<std::unique_ptr<std::array<uint8_t, Bytes>>> generateData(std::size_t size) {
     if (size > 8 * Bytes) {
         throw std::invalid_argument("Cannot have a size larger than the number of bits.");
     }
 
-    std::unique_ptr<std::vector<std::array<uint8_t, Bytes>>> data(new std::vector<std::array<uint8_t, Bytes>>(size));
+    std::vector<std::unique_ptr<std::array<uint8_t, Bytes>>> data(size);
+
+    for (auto& ptr : data) {
+        ptr = std::unique_ptr<std::array<uint8_t, Bytes>>(new std::array<uint8_t, Bytes>);
+    }
 
     /* all uint8_t arrays must be different from each other by 2 bits and 1 from the parent uint8_t array */
     for (std::size_t i = 0; i < size; i++) {
         const std::size_t byte_index = i / 8;
         const std::size_t bit_index = i % 8;
-        (*data)[i][byte_index] = (1 << bit_index);
+        (*data[i])[byte_index] = (1 << bit_index);
     }
 
     return data;
 }
 
 /* print the bits of each byte in a uint8_t array */
-template <std::size_t Size>
-void printBits(std::unique_ptr<std::array<uint8_t, Size>>& arr) {
-    for (std::size_t i = 0; i < Size; i++) {
+template <std::size_t Bytes>
+void printBits(const std::unique_ptr<std::array<uint8_t, Bytes>>& arr) {
+    for (std::size_t i = 0; i < Bytes; i++) {
         std::cout << std::bitset<8>{(*arr)[i]};
     }
     std::cout << '\n';
@@ -64,22 +69,20 @@ int main() {
     /* number of hashes to compare to parent hash */
     const std::size_t hashes_count = 60;
     /* number of bytes that each hash will be constructed from */
-    const std::size_t bytes = 32423434;
+    const std::size_t bytes = 10;
 
     /* parent uint8_t array to compare our data with */
-    std::unique_ptr<std::array<uint8_t, bytes>> parent(new std::array<uint8_t, bytes>);
+    std::unique_ptr<std::array<uint8_t, bytes>> parent(new std::array<uint8_t, bytes>());
 
-    std::unique_ptr<std::vector<std::array<uint8_t, bytes>>> data(generateData<bytes>(hashes_count));
-
-    printBits(parent);
+    std::vector<std::unique_ptr<std::array<uint8_t, bytes>>> data(generateData<bytes>(hashes_count));
 
     /* sum the number of different bits from all hashes */
-    // int count = 0;
-    // for (std::size_t i = 0; i < hashes_count; i++) {
-    //     //printBits((*data)[i]);
-    //     count += countDiffBits(sha256(*parent), sha256((*data)[i]));
-    // }
-    // /* output the average hamming weight, which should be something around 0.5 */
-    // std::cout << "average hamming weight is: " << count / (float)((hashes_count)*256) << '\n';
+    int count = 0;
+    for (const auto& arr : data) {
+        printBits(arr);
+        count += countDiffBits(sha256(parent), sha256(arr));
+    }
+    /* output the average hamming weight, which should be something around 0.5 */
+    std::cout << "average hamming weight is: " << count / (float)((hashes_count)*256) << '\n';
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,15 +3,15 @@
 #include <algorithm>
 #include <array>
 #include <bitset>
-#include <cstring>
 #include <iomanip>
 #include <iostream>
+#include <memory>
 #include <vector>
 
 #include "string_functions.hpp"
 
 /* OpenSSL sha256 function */
-template<std::size_t Size>
+template <std::size_t Size>
 std::string sha256(const std::array<uint8_t, Size> arr) {
     unsigned char hash[SHA256_DIGEST_LENGTH];
     SHA256_CTX sha256;
@@ -26,7 +26,7 @@ std::string sha256(const std::array<uint8_t, Size> arr) {
 }
 
 /* generate a vector of arrays of uint8_t's to feed into sha256 */
-template<std::size_t Bytes>
+template <std::size_t Bytes>
 std::unique_ptr<std::vector<std::array<uint8_t, Bytes>>> generateData(std::size_t size) {
     if (size > 8 * Bytes) {
         throw std::invalid_argument("Cannot have a size larger than the number of bits.");
@@ -45,10 +45,10 @@ std::unique_ptr<std::vector<std::array<uint8_t, Bytes>>> generateData(std::size_
 }
 
 /* print the bits of each byte in a uint8_t array */
-template<std::size_t Size>
-void printBits(std::array<uint8_t, Size> arr) {
+template <std::size_t Size>
+void printBits(std::unique_ptr<std::array<uint8_t, Size>>& arr) {
     for (std::size_t i = 0; i < Size; i++) {
-        std::cout << std::bitset<8>{arr[i]};
+        std::cout << std::bitset<8>{(*arr)[i]};
     }
     std::cout << '\n';
 }
@@ -71,13 +71,15 @@ int main() {
 
     std::unique_ptr<std::vector<std::array<uint8_t, bytes>>> data(generateData<bytes>(hashes_count));
 
+    printBits(parent);
+
     /* sum the number of different bits from all hashes */
-    int count = 0;
-    for (std::size_t i = 0; i < hashes_count; i++) {
-        //printBits((*data)[i]);
-        count += countDiffBits(sha256(*parent), sha256((*data)[i]));
-    }
-    /* output the average hamming weight, which should be something around 0.5 */
-    std::cout << "average hamming weight is: " << count / (float)((hashes_count)*256) << '\n';
+    // int count = 0;
+    // for (std::size_t i = 0; i < hashes_count; i++) {
+    //     //printBits((*data)[i]);
+    //     count += countDiffBits(sha256(*parent), sha256((*data)[i]));
+    // }
+    // /* output the average hamming weight, which should be something around 0.5 */
+    // std::cout << "average hamming weight is: " << count / (float)((hashes_count)*256) << '\n';
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,11 +13,11 @@
 
 /* OpenSSL sha256 function */
 template <std::size_t Size>
-std::string sha256(const std::unique_ptr<std::array<uint8_t, Size>>& arr) {
+std::string sha256(const std::unique_ptr<std::array<uint8_t, Size>>& ptr) {
     unsigned char hash[SHA256_DIGEST_LENGTH];
     SHA256_CTX sha256;
     SHA256_Init(&sha256);
-    SHA256_Update(&sha256, (*arr).data(), Size);
+    SHA256_Update(&sha256, (*ptr).data(), Size);
     SHA256_Final(hash, &sha256);
     std::stringstream ss;
     for (int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
@@ -36,13 +36,14 @@ std::vector<std::unique_ptr<std::array<uint8_t, Bytes>>> generateData(std::size_
     std::vector<std::unique_ptr<std::array<uint8_t, Bytes>>> data(size);
 
     for (auto& ptr : data) {
-        ptr = std::unique_ptr<std::array<uint8_t, Bytes>>(new std::array<uint8_t, Bytes>);
+        ptr = std::move(std::unique_ptr<std::array<uint8_t, Bytes>>(new std::array<uint8_t, Bytes>));
     }
 
     /* all uint8_t arrays must be different from each other by 2 bits and 1 from the parent uint8_t array */
     for (std::size_t i = 0; i < size; i++) {
         const std::size_t byte_index = i / 8;
         const std::size_t bit_index = i % 8;
+
         (*data[i])[byte_index] = (1 << bit_index);
     }
 
@@ -78,9 +79,9 @@ int main() {
 
     /* sum the number of different bits from all hashes */
     int count = 0;
-    for (const auto& arr : data) {
-        printBits(arr);
-        count += countDiffBits(sha256(parent), sha256(arr));
+    for (const auto& ptr : data) {
+        // printBits(arr);
+        count += countDiffBits(sha256(parent), sha256(ptr));
     }
     /* output the average hamming weight, which should be something around 0.5 */
     std::cout << "average hamming weight is: " << count / (float)((hashes_count)*256) << '\n';

--- a/src/string_functions.cpp
+++ b/src/string_functions.cpp
@@ -6,29 +6,62 @@ std::string strtb(const std::string_view hex) {
     std::stringstream ss;
     while (hex[i]) {
         switch (hex[i]) {
-            case '0': ss << "0000"; break;
-            case '1': ss << "0001"; break;
-            case '2': ss << "0010"; break;
-            case '3': ss << "0011"; break;
-            case '4': ss << "0100"; break;
-            case '5': ss << "0101"; break;
-            case '6': ss << "0110"; break;
-            case '7': ss << "0111"; break;
-            case '8': ss << "1000"; break;
-            case '9': ss << "1001"; break;
+            case '0':
+                ss << "0000";
+                break;
+            case '1':
+                ss << "0001";
+                break;
+            case '2':
+                ss << "0010";
+                break;
+            case '3':
+                ss << "0011";
+                break;
+            case '4':
+                ss << "0100";
+                break;
+            case '5':
+                ss << "0101";
+                break;
+            case '6':
+                ss << "0110";
+                break;
+            case '7':
+                ss << "0111";
+                break;
+            case '8':
+                ss << "1000";
+                break;
+            case '9':
+                ss << "1001";
+                break;
             case 'A':
-            case 'a': ss << "1010"; break;
+            case 'a':
+                ss << "1010";
+                break;
             case 'B':
-            case 'b': ss << "1011"; break;
+            case 'b':
+                ss << "1011";
+                break;
             case 'C':
-            case 'c': ss << "1100"; break;
+            case 'c':
+                ss << "1100";
+                break;
             case 'D':
-            case 'd': ss << "1101"; break;
+            case 'd':
+                ss << "1101";
+                break;
             case 'E':
-            case 'e': ss << "1110"; break;
+            case 'e':
+                ss << "1110";
+                break;
             case 'F':
-            case 'f': ss << "1111"; break;
-            default: std::cout << "\nlease enter valid hexadecimal digit " << hex[i];
+            case 'f':
+                ss << "1111";
+                break;
+            default:
+                std::cout << "\nplease enter valid hexadecimal digit " << hex[i];
         }
         i++;
     }


### PR DESCRIPTION
Switched to unique_ptr<T> to store arrays and also added compiler version checks inside CMakeLists.txt because some older version were causing segfaults when number of bytes was too big.